### PR TITLE
Remove dependencies installation via `yum`

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -43,22 +43,7 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
-(
-# Due to https://bugzilla.redhat.com/show_bug.cgi?id=1537564 old versions of rpm
-# are drastically slowed down when the number of file descriptors is very high.
-# This can be visible during a `yum install` step of a feedstock build.
-# => Set a lower limit in a subshell for the `yum install`s only.
-ulimit -n 1024
-
-# Install the yum requirements defined canonically in the
-# "recipe/yum_requirements.txt" file. After updating that file,
-# run "conda smithy rerender" and this line will be updated
-# automatically.
-/usr/bin/sudo -n yum install -y mesa-libGL mesa-dri-drivers libselinux libXdamage libXxf86vm libXext
-
-
-
-)# make the build number clobber
+# make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ test:
     - git
     - pip
     # Extra [testing] dependencies:
-    - idyntree >= 12.2.1
+    - idyntree >= 12.4
     - pytest >= 6.0
     - pytest-icdiff
     - robot_descriptions

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,6 +1,0 @@
-mesa-libGL
-mesa-dri-drivers
-libselinux
-libXdamage
-libXxf86vm
-libXext


### PR DESCRIPTION
This PR removes the installation of dependencies not available on conda-forge with yum, which has been introduced in https://github.com/conda-forge/jaxsim-feedstock/pull/5 and solved in https://github.com/conda-forge/idyntree-feedstock/pull/99.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
